### PR TITLE
Concise

### DIFF
--- a/algorithms/alg.bind-game.tex
+++ b/algorithms/alg.bind-game.tex
@@ -2,7 +2,7 @@
 \begin{algorithm}[H]
     \caption{\label{alg.bind-game} The challenger for the burn protocol game-based security.}
     \begin{algorithmic}[1]
-        \Function{\textsc{bind-attack}$_{\mathcal{A},\Pi}$}{$\kappa$}
+        \Function{\bindattack$_{\mathcal{A},\Pi}$}{$\kappa$}
             \Let{(t, t', \burnAddr)}{\mathcal{A}(1^\kappa)}
             \State\Return{$(t \neq t' \land \BurnVerify(1^\kappa, t, \burnAddr) \land \BurnVerify(1^\kappa, t', \burnAddr))$}
         \EndFunction

--- a/algorithms/alg.bind-game.tex
+++ b/algorithms/alg.bind-game.tex
@@ -4,11 +4,7 @@
     \begin{algorithmic}[1]
         \Function{\textsc{bind-attack}$_{\mathcal{A},\Pi}$}{$\kappa$}
             \Let{(t, t', \burnAddr)}{\mathcal{A}(1^\kappa)}
-            \If{$t \neq t' \land \BurnVerify(1^\kappa, t, \burnAddr) \land \BurnVerify(1^\kappa, t', \burnAddr)$}
-                \State\Return{\sf true}
-            \Else
-                \State\Return{\sf false}
-            \EndIf
+            \State\Return{$(t \neq t' \land \BurnVerify(1^\kappa, t, \burnAddr) \land \BurnVerify(1^\kappa, t', \burnAddr))$}
         \EndFunction
     \end{algorithmic}
 \end{algorithm}

--- a/algorithms/alg.bitcoin-real.tex
+++ b/algorithms/alg.bitcoin-real.tex
@@ -9,7 +9,7 @@
             \If{main net}
               \Let{addr}{\texttt{0x00} || pkh'}
             \Else
-              \CommentLine{Test net}
+              \Comment{Test net}
               \Let{addr}{\texttt{0x6f} || pkh'}
             \EndIf
             \Let{checksum}{\textsf{SHA256}(\textsf{SHA256}(addr))[4 * 8]}

--- a/algorithms/alg.bitcoin.tex
+++ b/algorithms/alg.bitcoin.tex
@@ -10,10 +10,7 @@
         \EndFunction
         \Function{$\SpendVerify_{S, H}$}{$m, \sigma, pkh$}
             \Let{(pk, \sigma')}{\sigma}
-            \If{$H_\kappa(pk) \neq pkh$}
-                \State\Return\textsf{false}
-            \EndIf
-            \State\Return{$\Ver(m, \sigma', pk)$}
+            \State\Return{$(H_\kappa(pk) \neq pkh \land \Ver(m, \sigma', pk))$}
         \EndFunction
         \vskip8pt
     \end{algorithmic}

--- a/algorithms/alg.collision-resistance-adversary.tex
+++ b/algorithms/alg.collision-resistance-adversary.tex
@@ -1,6 +1,6 @@
 \begin{figure}[t]
 \begin{algorithm}[H]
-    \caption{\label{alg.collision-resistance-adversary} The Collision Resistance adversary against $H$ using a proof-of-burn \textsc{bind-attack} adversary $\mathcal{A}$.}
+    \caption{\label{alg.collision-resistance-adversary} The Collision Resistance adversary against $H$ using a proof-of-burn $\bindattack$ adversary $\mathcal{A}$.}
     \begin{algorithmic}[1]
         \Function{$\mathcal{A}^*_{\mathcal{A}}$}{$1^\kappa$}
             \Let{(t, t', \_)}{\mathcal{A}(1^\kappa)}

--- a/algorithms/alg.construction.tex
+++ b/algorithms/alg.construction.tex
@@ -9,11 +9,7 @@
             \State\Return{th'}
         \EndFunction
         \Function{$\BurnVerify_H$}{$1^\kappa, t, th'$}
-            \If{$\GenBurnAddress_H(1^\kappa, t) = th'$}
-                \State\Return\textsf{true}
-            \Else
-                \State\Return\textsf{false}
-            \EndIf
+            \State\Return{$(\GenBurnAddress_H(1^\kappa, t) = th')$}
         \EndFunction
         \vskip8pt
     \end{algorithmic}

--- a/algorithms/alg.dist-game.tex
+++ b/algorithms/alg.dist-game.tex
@@ -7,11 +7,7 @@
             \Let{z}{D_b}
 
             \Let{b^*}{\mathcal{A}(z, 1^\kappa)}
-            \If{$b = b^*$}
-                \State\Return{\sf true}
-            \Else
-                \State\Return{\sf false}
-            \EndIf
+            \State\Return{$(b = b^*)$}
         \EndFunction
     \end{algorithmic}
 \end{algorithm}

--- a/algorithms/alg.predict-game.tex
+++ b/algorithms/alg.predict-game.tex
@@ -5,11 +5,7 @@
         \Function{\textsc{predict}$_{\mathcal{A},X}$}{$\kappa$}
             \Let{x}{X}
             \Let{x^*}{\mathcal{A}(1^\kappa)}
-            \If{$x = x^*$}
-                \State\Return{$\true$}
-            \Else
-                \State\Return{$\false$}
-            \EndIf
+            \State\Return{$(x = x^*)$}
         \EndFunction
     \end{algorithmic}
 \end{algorithm}

--- a/algorithms/alg.predictability-adversary.tex
+++ b/algorithms/alg.predictability-adversary.tex
@@ -15,7 +15,7 @@
             \State\Return$Q[i]$
         \EndFunction
         \Function{$\mathcal{A}^*_{X,\mathcal{A}}$}{$1^\kappa$}
-            \Let{b}{\{0,1\}}
+            \State{$b \stackrel{\$}{\leftarrow} \{0,1\}$}
             \If{$b = 0$}
                 \Let{z}{X}
                 \State$j \stackrel{\$}{\gets} [r]$

--- a/algorithms/alg.predictability-adversary.tex
+++ b/algorithms/alg.predictability-adversary.tex
@@ -24,11 +24,10 @@
             \EndIf
 
             \Let{b^*}{\mathcal{A}^{H'}(z)}
-            \If{$b = 0 \land j \text{ in } Q$}
-                \State\Return{Q[j]}
-            \Else
+            \If{$b = 1 \lor j > i$}
                 \State\Return{\textsc{failure}}
             \EndIf
+            \State\Return{Q[j]}
         \EndFunction
     \end{algorithmic}
 \end{algorithm}

--- a/algorithms/alg.spend-game.tex
+++ b/algorithms/alg.spend-game.tex
@@ -4,11 +4,7 @@
     \begin{algorithmic}[1]
         \Function{\textsc{spend-attack}$_{\mathcal{A},\Pi}$}{$\kappa$}
             \Let{(t, m, \sigma, pk)}{\mathcal{A}(1^\kappa)}
-            \If{$\BurnVerify(1^\kappa, t, pk) \land \SpendVerify(m, \sigma, pk)$}
-                \State\Return{\sf true}
-            \Else
-                \State\Return{\sf false}
-            \EndIf
+            \State\Return{$(\BurnVerify(1^\kappa, t, pk) \land \SpendVerify(m, \sigma, pk))$}
         \EndFunction
     \end{algorithmic}
 \end{algorithm}

--- a/algorithms/alg.spend-game.tex
+++ b/algorithms/alg.spend-game.tex
@@ -2,7 +2,7 @@
 \begin{algorithm}[H]
     \caption{\label{alg.spend-game} The challenger for the burn protocol game-based security.}
     \begin{algorithmic}[1]
-        \Function{\textsc{spend-attack}$_{\mathcal{A},\Pi}$}{$\kappa$}
+        \Function{\spendattack$_{\mathcal{A},\Pi}$}{$\kappa$}
             \Let{(t, m, \sigma, pk)}{\mathcal{A}(1^\kappa)}
             \State\Return{$(\BurnVerify(1^\kappa, t, pk) \land \SpendVerify(m, \sigma, pk))$}
         \EndFunction

--- a/analysis.tex
+++ b/analysis.tex
@@ -7,8 +7,6 @@ its correctness is straightforward to show.
   The Proof-of-Burn protocol $\Pi$ of Section~\ref{section:construction} is \emph{correct}.
 \end{theorem}
 \begin{proof}
-  We need to prove that $\forall \kappa, t. \BurnVerify(1^\kappa, t, \GenBurnAddress(1^\kappa, t)) = \textsf{true}$.
-
   Based on Algorithm~\ref{alg.construction}, $\BurnVerify(1^\kappa, t, \GenBurnAddress(1^\kappa, t)) = \textsf{true}$ if and only if $\GenBurnAddress(1^\kappa, t) = \GenBurnAddress(1^\kappa, t)$, which always holds as $\GenBurnAddress$ is deterministic.
 \end{proof}
 

--- a/analysis.tex
+++ b/analysis.tex
@@ -40,17 +40,15 @@ We will now apply the above lemma to show that our scheme is unspenable.
   If $H$ is a \emph{Random Oracle}, then the protocol $\Pi$ of Section~\ref{section:construction} is \emph{unspendable}.
 \end{theorem}
 \begin{proof}
-  Let $\mathcal{A}$ be an arbitrary probabilistic polynomial time \textsc{spend-attack} adversary.
+  Let $\mathcal{A}$ be an arbitrary probabilistic polynomial time $\spendattack$ adversary.
   The adversary $\mathcal{A}$ makes at most a polynomial number of queries $p(\kappa)$ to the Random Oracle.
   Consider the event \textsc{Match} of Lemma~\ref{lem.perturbation}.
 
   If the adversary is successful then it has presented $t, pk, pkh$ such that $H(pk) = pkh$ and $H(t) \xor 1 = pkh$.
-
-  We observe that $\textsc{spend-attack}_{\mathcal{A}, \Pi}(\kappa) = \true \Rightarrow \textsc{Match}$.
-
-  Therefore $\Pr[\textsc{spend-attack}_{\mathcal{A}, \Pi}(\kappa)] \leq Pr[\textsc{Match}]$. Applying Lemma~\ref{lem.perturbation} for the permutation $F(x) = x \xor 1$,
+  We observe that $\spendattack_{\mathcal{A}, \Pi}(\kappa) = \true \Rightarrow \textsc{Match}$.
+  Therefore $\Pr[\spendattack_{\mathcal{A}, \Pi}(\kappa)] \leq Pr[\textsc{Match}]$. Applying Lemma~\ref{lem.perturbation} for the permutation $F(x) = x \xor 1$,
   we obtain
-  $\Pr[\textsc{spend-attack}_{\mathcal{A}, \Pi}(\kappa)] \leq \negl$.
+  $\Pr[\spendattack_{\mathcal{A}, \Pi}(\kappa)] \leq \negl$.
 \end{proof}
 
 We note that the security of the signature scheme is not needed to prove unspendability. Were the signature scheme of the underlying cryptocurrency ever found to be \emph{forgeable}, the coins burned through our scheme would remain unspendable. We additionally remark that the

--- a/analysis.tex
+++ b/analysis.tex
@@ -22,12 +22,10 @@ outputs.
 \begin{proof}
   Let \textsc{Match} denote the event that there exist $1 \leq i \neq j \leq p(\kappa)$ such that $s_i = F(s_j)$.
   Let $\textsc{Match}_{i, j}$ denote the event that $s_i = F(s_j)$. Apply a union bound to obtain
-
-  \begin{align*}
-    \Pr[\bigcup_{i, j}\textsc{Match}_{i, j}] &\leq \sum_{i, j} \Pr[\textsc{Match}_{i, j}] \\
-    \Pr[\textsc{Match}] &\leq \sum_{i, j} \Pr[\textsc{Match}_{i, j}]
-  \end{align*}
-
+  $
+    \Pr[\bigcup_{i, j}\textsc{Match}_{i, j}] \leq \sum_{i, j} \Pr[\textsc{Match}_{i, j}]
+    \Pr[\textsc{Match}] \leq \sum_{i, j} \Pr[\textsc{Match}_{i, j}]
+  $.
   But $\Pr[\textsc{Match}_{i, j}] = 2^{-p(\kappa)}$ and therefore
   $\Pr[\textsc{Match}] \leq \sum_{i \neq j} 2^{-p(\kappa)} \leq p^2(\kappa) 2^{-p(\kappa)}$.
 \end{proof}

--- a/definition.tex
+++ b/definition.tex
@@ -14,6 +14,15 @@ Let $\kappa$ be the security parameter.
 
 Intuitively, the protocol works as follows. If Alice wishes to burn coins on a source blockchain in order to generate coins on a destination blockchain, Alice first generates a receiving address on the destination blockchain to which she will receive the coins in question. That receiving address, along with any potential metadata desired, is then encoded into the tag $t$. Alice then calls $\GenBurnAddress(1^\kappa, t)$ to generate a burn address $\burnAddr$, which is a valid address on the source blockchain. Alice can then send money to $\burnAddr$ on the source blockchain. That money is destroyed and unspendable. Alice can present the tag $t$ to Bob who wishes to verify that $\burnAddr$ really is a burn address. Bob calls $\BurnVerify(1^\kappa, t, \burnAddr)$ and ensures that it returns $\true$. When Bob sees Alice's transaction which spends money to $\burnAddr$ on the source blockchain, he knows that the money really is unspendable and was sent by Alice with the intention of receiving the corresponding amount to address $t$ on the destination blockchain.
 
+We require that the burn scheme is \emph{correct}.
+
+\begin{definition}[Correctness]
+  A burn protocol $\Pi$ is \emph{correct} if for all $t \in \{0,1\}^*$ and for all $\kappa \in \mathbb{N}$ it holds that
+  $\BurnVerify(1^\kappa, t, \GenBurnAddress(1^\kappa, t)) = \true$.
+\end{definition}
+
+With foresight, we remark that the implementation of $\GenBurnAddress$ and $\BurnVerify$ will typically be deterministic, which alleviates the need for a probabilistic correctness definition.
+
 Naturally, for $\GenBurnAddress$ to generate addresses that ``look'' valid but are unspendable according to the source blockchain protocol requires that the burn protocol respects the format of the source blockchain protocol. We abstract the functionalities of the source blockchain protocol into a \emph{blockchain address protocol}:
 
 \begin{definition}[Blockchain address protocol]
@@ -26,18 +35,9 @@ Naturally, for $\GenBurnAddress$ to generate addresses that ``look'' valid but a
   \end{itemize}
 \end{definition}
 
-We note that, while the blockchain address protocol is not part of the burn protocol, the \emph{correctness} and \emph{security} properties of a burn protocol $\Pi$ will be defined with respect to a \emph{blockchain address protocol} $\Pi_\alpha$.
+We note that, while the blockchain address protocol is not part of the burn protocol, the \emph{security} properties of a burn protocol $\Pi$ will be defined with respect to a \emph{blockchain address protocol} $\Pi_\alpha$.
 
-These two functionalities are typically implemented using a standard public-key signature scheme and are accompanied by a respective signing algorithm. The signing algorithm is irrelevant for our burn purposes, since burning entails the inability to spend. We intentionally leave the format of the transaction $m$ undefined. We remark here that the format of $m$ is cryptocurrency-specific. In both Bitcoin and Ethereum, $m$ corresponds to transaction data. When a new candidate transaction is received from the network, the blockchain node calls $\textsf{SpendVerify}$, passing the public key $pk$ who is spending money incoming to the new transaction $m$ together with a signature $\sigma$ which should be produced using the respective secret key and signs transaction $m$. In the case of Bitcoin's p2pkh, $pk$ and $\sigma$ can be extracted from the scriptSig data, while $m$ contains the new scriptPubKey~\cite{bitcoin-dev-guide}.
-
-We require that the burn scheme is \emph{correct}. That is, if a burn address is generated correctly it should verify.
-
-\begin{definition}[Correctness]
-  A burn protocol $\Pi$ is \emph{correct} with respect to a blockchain address protocol $\Pi_\alpha$ if for all $t$ and for all $\kappa$ it holds that
-  $\BurnVerify(1^\kappa, t, \GenBurnAddress(1^\kappa, t)) = \textsf{true}$.
-\end{definition}
-
-With foresight, we remark that the implementation of $\GenBurnAddress$ and $\BurnVerify$ will be deterministic, which alleviates the need for a probabilistic correctness definition.
+These two functionalities are typically implemented using a standard public-key signature scheme and are accompanied by a respective signing algorithm. The signing algorithm is irrelevant for our burn purposes, since burning entails the inability to spend. We intentionally leave the format of the transaction $m$ undefined. We remark here that the format of $m$ is cryptocurrency-specific. In both Bitcoin and Ethereum, $m$ corresponds to transaction data. When a new candidate transaction is received from the network, the blockchain node calls $\textsf{SpendVerify}$, passing the public key $pk$ which is spending money incoming to the new transaction $m$ together with a signature $\sigma$ which should be produced using the respective secret key and signs transaction $m$. In the case of Bitcoin's p2pkh, $pk$ and $\sigma$ can be extracted from the scriptSig data, while $m$ contains the new scriptPubKey~\cite{bitcoin-dev-guide}.
 
 To state that the protocol generates addresses which cannot be spent from, we introduce a game-based security definition. The unspendability game $\spendattack$ is illustrated in Algorithm~\ref{alg.spend-game}.
 
@@ -45,7 +45,6 @@ To state that the protocol generates addresses which cannot be spent from, we in
 
 \begin{definition}[Unspendability]
   A burn protocol $\Pi$ is \emph{unspendable} with respect to a blockchain address protocol $\Pi_\alpha$ if
-<<<<<<< HEAD
   for all probabilistic polynomial-time adversaries $\mathcal{A}$ there exists a negligible function $\negl$ such that
   $
     \Pr[\spendattack_{\mathcal{A}, \Pi}(\kappa) = \textsf{true}] \leq \negl
@@ -63,12 +62,12 @@ To state that the protocol generates addresses which cannot be spent from, we in
   \]
 \end{definition}
 
-We note here that the binding property of a burn protocol is irrespective of the blockchain address protocol it was designed for.
+We note here that the correctness and binding properties of a burn protocol are irrespective of the blockchain address protocol it was designed for.
 
 We are now ready to define what constitutes a \emph{secure proof-of-burn protocol}.
 
 \begin{definition}[Security]
-  Let $\Pi$ be a burn protocol correct with respect to a blockchain address protocol $\Pi_\alpha$. We say that $\Pi$ is \emph{secure} if it is \emph{unspendable} and \emph{binding}.
+  Let $\Pi$ be a correct burn protocol correct. We say that $\Pi$ is \emph{secure} with respect to a blockchain address protocol $\Pi_\alpha$ if it is \emph{unspendable} and \emph{binding} with respect to $\Pi_\alpha$.
 \end{definition}
 
 The aforementioned properties form a good basis for a burn protocol. We observe that it may be possible to detect whether an address is a burn address. While this is desirable in certain circumstances, it allows miners to censor burn transactions. To mitigate this, we propose \emph{uncensorability}, a property which mandates that a burn address is indistinguishable from a regular address if its tag is not known. During the execution of protocols which satisfy this property, when the burn transaction appears on the network, only the user who performed the burn knows that it constitutes a burn transaction prior to revealing the tag. Naturally, as soon as the tag is revealed, \emph{correctness} mandates that the burn transaction becomes verifiable.

--- a/definition.tex
+++ b/definition.tex
@@ -55,11 +55,7 @@ To state that the protocol generates addresses which cannot be spent from, we in
 
 \begin{definition}[Binding]
   A burn protocol $\Pi$ is \emph{binding} if
-  for all probabilistic polynomial-time adversaries $\mathcal{A}$ it holds that:
-
-  \[
-    \Pr[\bindattack_{\mathcal{A},\Pi}(\kappa)] \leq \negl
-  \]
+  for all probabilistic polynomial-time adversaries $\mathcal{A}$ it holds that $\Pr[\bindattack_{\mathcal{A},\Pi}(\kappa)] \leq \negl$.
 \end{definition}
 
 We note here that the correctness and binding properties of a burn protocol are irrespective of the blockchain address protocol it was designed for.

--- a/definition.tex
+++ b/definition.tex
@@ -39,18 +39,17 @@ We require that the burn scheme is \emph{correct}. That is, if a burn address is
 
 With foresight, we remark that the implementation of $\GenBurnAddress$ and $\BurnVerify$ will be deterministic, which alleviates the need for a probabilistic correctness definition.
 
-To state that the protocol generates addresses which cannot be spent from, we introduce a game-based security definition. The unspendability game \textsc{spend-attack} is illustrated in Algorithm~\ref{alg.spend-game}.
+To state that the protocol generates addresses which cannot be spent from, we introduce a game-based security definition. The unspendability game $\spendattack$ is illustrated in Algorithm~\ref{alg.spend-game}.
 
 \import{./}{algorithms/alg.spend-game.tex}
 
 \begin{definition}[Unspendability]
   A burn protocol $\Pi$ is \emph{unspendable} with respect to a blockchain address protocol $\Pi_\alpha$ if
-  for all probabilistic polynomial-time adversaries $\mathcal{A}$ there exists a negligible function $\negl$ such that:
-
-  \[
-    \Pr[\textsc{spend-attack}_{\mathcal{A},
-    \Pi}(\kappa) = \textsf{true}] \leq \negl
-  \]
+<<<<<<< HEAD
+  for all probabilistic polynomial-time adversaries $\mathcal{A}$ there exists a negligible function $\negl$ such that
+  $
+    \Pr[\spendattack_{\mathcal{A}, \Pi}(\kappa) = \textsf{true}] \leq \negl
+  $.
 \end{definition}
 
 \import{./}{algorithms/alg.bind-game.tex}
@@ -60,7 +59,7 @@ To state that the protocol generates addresses which cannot be spent from, we in
   for all probabilistic polynomial-time adversaries $\mathcal{A}$ it holds that:
 
   \[
-    \Pr[\textsc{bind-attack}_{\mathcal{A},\Pi}(\kappa)] \leq \negl
+    \Pr[\bindattack_{\mathcal{A},\Pi}(\kappa)] \leq \negl
   \]
 \end{definition}
 

--- a/definition.tex
+++ b/definition.tex
@@ -55,7 +55,9 @@ To state that the protocol generates addresses which cannot be spent from, we in
 
 \begin{definition}[Binding]
   A burn protocol $\Pi$ is \emph{binding} if
-  for all probabilistic polynomial-time adversaries $\mathcal{A}$ it holds that $\Pr[\bindattack_{\mathcal{A},\Pi}(\kappa)] \leq \negl$.
+  for all probabilistic polynomial-time adversaries $\mathcal{A}$ there is a
+  negligible function $\negl$ such that
+  $\Pr[\bindattack_{\mathcal{A},\Pi}(\kappa)] \leq \negl$.
 \end{definition}
 
 We note here that the correctness and binding properties of a burn protocol are irrespective of the blockchain address protocol it was designed for.

--- a/macros.tex
+++ b/macros.tex
@@ -146,7 +146,7 @@
 
 \newcommand{\GenAddress}{\mathsf{GenAddress}}
 \newcommand{\SpendVerify}{\mathsf{SpendVerify}}
-\newcommand{\GenBurnAddress}{\mathsf{GenBurnAddress}}
+\newcommand{\GenBurnAddress}{\mathsf{Gen}\-\mathsf{Burn}\-\mathsf{Address}}
 \newcommand{\BurnVerify}{\mathsf{BurnVerify}}
 \newcommand{\burnAddr}{\mathsf{burnAddr}}
 
@@ -157,3 +157,6 @@
 \newcommand{\uniformk}{\uniform(\{0,1\}^\kappa)}
 \newcommand{\extqry}{\textsc{exqry}}
 \newcommand{\negl}{\textsf{negl}(\kappa)}
+
+\newcommand{\spendattack}{\textsc{spend}\-\text{-}\-\textsc{attack}}
+\newcommand{\bindattack}{\textsc{bind}\-\text{-}\-\textsc{attack}}


### PR DESCRIPTION
* Improve hyphenation to avoid overfull boxes
* Shorten if(bool){return true}else{return false} into return(bool)
* Rephrase correctness without reference to $\Pi_\alpha$
* Add missing \exists\negl
* Minor shortening by removing unnecessary statements and new lines, and inlining eqns